### PR TITLE
+ Remove the manifest

### DIFF
--- a/src/sfdx4csharp.csproj
+++ b/src/sfdx4csharp.csproj
@@ -34,6 +34,7 @@ limitations under the License.
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Got this in our support inbox:

Hey guys, whenever I deploy an app with sfdx4csharp referenced I get an error saying "Reference in the manifest does not match the identity of the downloaded assembly sfdx4csharp.exe."

Trying something.